### PR TITLE
feat: improved extendability and type safety of header parsing

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -1,10 +1,40 @@
 #pragma once
 
-#include <cstdint>
-#include <string>
+#include "helpers/field.hpp"
+#include "helpers/field_types.hpp"
 
 namespace cc::tar::common {
 
+using FILE_NAME = helpers::Field<0, 100, helpers::String_t>;
+
+using FILE_MODE = helpers::Field<100, 8, helpers::Octal_t>;
+
+using USER_ID = helpers::Field<108, 8, helpers::Octal_t>;
+
+using GROUP_ID = helpers::Field<116, 8, helpers::Octal_t>;
+
+using FILE_SIZE = helpers::Field<124, 12, helpers::Octal_t>;
+
+using LAST_MODIFIED = helpers::Field<136, 12, helpers::Octal_t>;
+
+using CHECKSUM = helpers::Field<148, 12, helpers::Octal_t>;
+
+/**
+ * @brief Set of values for \ref LINK_INDICATOR
+ */
+enum class LinkIndicator : char {
+  NORMAL_FILE = '0',
+  HARD_LINK = '1',
+  SYMBOLIC_LINK = '2',
+};
+
+using LINK_INDICATOR =
+    helpers::Field<156, 1, helpers::EnumClass_t<LinkIndicator>>;
+
+using LINKED_FILE_NAME = helpers::Field<157, 100, helpers::String_t>;
+
+// TODO Replace with better way of doing this..
+// Perhaps general container with fields similar to cib
 struct ObjectHeader {
   std::string fileName;
   std::uint64_t fileSize;
@@ -13,7 +43,7 @@ struct ObjectHeader {
   std::uint64_t userID;
   std::uint64_t groupID;
 
-  uint8_t linkIndicator;
+  LinkIndicator linkIndicator;
   std::string linkedFileName;
 };
 

--- a/include/helpers/field.hpp
+++ b/include/helpers/field.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "error.hpp"
+#include <span>
+
+namespace cc::tar::helpers {
+
+template <typename T>
+concept FieldValueType = requires(std::span<char> span) {
+  typename T::value_type;
+  {
+    T::Serialise(std::declval<typename T::value_type>(), span)
+  } -> std::same_as<Status>;
+  { T::Parse(span) } -> std::same_as<Result<typename T::value_type>>;
+};
+
+template <typename T>
+concept FieldType = std::unsigned_integral<decltype(T::offset)> &&
+                    std::unsigned_integral<decltype(T::size)> &&
+                    requires { typename T::value_type; };
+
+/**
+ * @brief Represents a field in the tar object header
+ * @tparam Offset the offset of the field with respect to the start of the
+ * header buffer
+ * @tparam Size the size of the field
+ * @tparam Type the wrapper type of the data contained within the field
+ */
+template <std::uint16_t Offset, std::uint16_t Size, FieldValueType Type>
+struct Field {
+  using field_type = Type;
+  using value_type = Type::value_type;
+  static constexpr auto offset = Offset;
+  static constexpr auto size = Size;
+};
+
+/**
+ * @brief Read the value of the specified field from the tar object header
+ * buffer
+ * @tparam Field the field of which the value should be read
+ * @param buffer the buffer that contains the tar object header
+ * @returns the value of the field if valid, 'NewError{}' otherwise
+ */
+template <FieldType Field>
+[[nodiscard]] Result<typename Field::value_type> Read(std::span<char> buffer) {
+  std::span<char> fieldBuffer(&buffer[Field::offset], Field::size);
+  return Field::field_type::Parse(fieldBuffer);
+}
+
+/**
+ * @brief Write the provided value to the specified field of the tar object
+ * header buffer
+ * @tparam Field the field to which the value should be written
+ * @param value the value to be written
+ * @param buffer the buffer that represents the tar object header
+ * @return 'Success()' if no error were encountered, 'NewError{}' otherwise
+ */
+template <FieldType Field>
+Status Write(typename Field::value_type value, std::span<char> buffer) {
+  std::span<char> fieldBuffer(&buffer[Field::offset], Field::size);
+  return Field::field_type::Serialise(value, fieldBuffer);
+}
+
+} // namespace cc::tar::helpers

--- a/include/helpers/field_types.hpp
+++ b/include/helpers/field_types.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <span>
+#include <string>
+
+#include "error.hpp"
+
+namespace cc::tar::helpers {
+
+struct String_t {
+  using value_type = std::string;
+
+  static Status Serialise(value_type value, std::span<char> buffer) {
+    if (value.size() + 1 > buffer.size())
+      return NewError(InvalidConversion{});
+    std::copy_n(value.c_str(), value.size() + 1, buffer.begin());
+    return Success();
+  }
+
+  static Result<value_type> Parse(std::span<char> buffer) {
+    return {{buffer.data()}};
+  }
+};
+
+struct Octal_t {
+  using value_type = std::uint64_t;
+
+  static Status Serialise(value_type value, std::span<char> buffer) {
+    auto [ptr, ec] =
+        std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, 8);
+    if (ec != std::errc()) {
+      return NewError(InvalidConversion{});
+    }
+    return Success();
+  }
+
+  static Result<value_type> Parse(std::span<char> buffer) {
+    value_type result{};
+    auto [ptr, ec] = std::from_chars(buffer.data(),
+                                     buffer.data() + buffer.size(), result, 8);
+    if (ec != std::errc()) {
+      return NewError(InvalidConversion{});
+    }
+    return {result};
+  }
+};
+
+template <typename T>
+concept EnumClassConvertibleToCharType =
+    std::is_enum_v<T> && std::is_same_v<std::underlying_type_t<T>, char> &&
+    (!std::is_convertible_v<T, int>); // Enum class requirement
+
+template <EnumClassConvertibleToCharType T> struct EnumClass_t {
+  using value_type = T;
+
+  static Status Serialise(value_type value, std::span<char> buffer) {
+    buffer[0] = static_cast<char>(value);
+    return Success();
+  }
+
+  static Result<value_type> Parse(std::span<char> buffer) {
+    value_type result = static_cast<value_type>(buffer[0]);
+    return {result};
+  }
+};
+
+} // namespace cc::tar::helpers

--- a/src/detail.cpp
+++ b/src/detail.cpp
@@ -5,29 +5,11 @@
 #include "error.hpp"
 
 #include <algorithm>
-#include <charconv>
 #include <cstdint>
-#include <cstdlib>
 #include <numeric>
 #include <span>
 
 namespace cc::tar::detail {
-
-// TODO
-// Not a very type safe approach
-// Better approach involves templates to define fields
-// Would make formatting much easier as well
-struct HeaderOffsets {
-  static constexpr std::uint16_t FILE_NAME = 0;
-  static constexpr std::uint16_t FILE_MODE = 100;
-  static constexpr std::uint16_t USER_ID = 108;
-  static constexpr std::uint16_t GROUP_ID = 116;
-  static constexpr std::uint16_t FILE_SIZE = 124;
-  static constexpr std::uint16_t LAST_MODIFIED = 136;
-  static constexpr std::uint16_t CHECKSUM = 148;
-  static constexpr std::uint16_t LINK_INDICATOR = 156;
-  static constexpr std::uint16_t LINKED_FILE_NAME = 157;
-};
 
 static constexpr std::uint16_t HEADER_SIZE_B = 257;
 
@@ -38,15 +20,16 @@ std::uint64_t CalculateChecksum(std::span<char> buffer) {
   };
 
   return std::accumulate(buffer.begin(), buffer.end(), 0, unsignedSum) -
-         std::accumulate(buffer.begin() + HeaderOffsets::CHECKSUM,
-                         buffer.begin() + HeaderOffsets::CHECKSUM + 8, 0,
-                         unsignedSum) +
+         std::accumulate(buffer.begin() + common::CHECKSUM::offset,
+                         buffer.begin() + common::CHECKSUM::offset +
+                             common::CHECKSUM::size,
+                         0, unsignedSum) +
          8 * static_cast<uint8_t>('0');
 }
 
 Status VerifyChecksum(std::span<char> buffer) {
-  std::uint64_t headerCheckSum =
-      strtoull(&buffer[HeaderOffsets::CHECKSUM], nullptr, 8);
+  using namespace cc::tar::helpers;
+  BOOST_LEAF_AUTO(headerCheckSum, Read<common::CHECKSUM>(buffer));
   auto checkSum = CalculateChecksum(buffer);
 
   if (checkSum != headerCheckSum)
@@ -56,65 +39,43 @@ Status VerifyChecksum(std::span<char> buffer) {
 
 // Parsing and serialisation
 Result<common::ObjectHeader> ParseHeader(std::span<char> buffer) {
+  using namespace cc::tar::helpers;
   if (buffer.size_bytes() < HEADER_SIZE_B)
     return NewError(InvalidBufferSize{});
 
   BOOST_LEAF_CHECK(VerifyChecksum(buffer));
 
   common::ObjectHeader header{};
-  header.fileName = std::string(buffer.data());
-  header.fileSize = strtoull(&buffer[HeaderOffsets::FILE_SIZE], nullptr, 8);
-  header.fileMode = strtoull(&buffer[HeaderOffsets::FILE_MODE], nullptr, 8);
-  header.userID = strtoull(&buffer[HeaderOffsets::USER_ID], nullptr, 8);
-  header.groupID = strtoull(&buffer[HeaderOffsets::GROUP_ID], nullptr, 8);
-  header.linkIndicator = buffer[HeaderOffsets::LINK_INDICATOR] - '0';
-  header.linkedFileName =
-      std::string(buffer.data() + HeaderOffsets::LINKED_FILE_NAME);
+  BOOST_LEAF_ASSIGN(header.fileName, Read<common::FILE_NAME>(buffer));
+  BOOST_LEAF_ASSIGN(header.fileSize, Read<common::FILE_SIZE>(buffer));
+  BOOST_LEAF_ASSIGN(header.fileMode, Read<common::FILE_MODE>(buffer));
+  BOOST_LEAF_ASSIGN(header.userID, Read<common::USER_ID>(buffer));
+  BOOST_LEAF_ASSIGN(header.groupID, Read<common::GROUP_ID>(buffer));
+  BOOST_LEAF_ASSIGN(header.linkIndicator, Read<common::LINK_INDICATOR>(buffer));
+  BOOST_LEAF_ASSIGN(header.linkedFileName,
+                    Read<common::LINKED_FILE_NAME>(buffer));
   return header;
-}
-
-inline Status ToOctalCharsN(std::uint64_t value, char *destination,
-                            std::uint64_t maxLength) {
-  auto [ptr, ec] =
-      std::to_chars(destination, destination + maxLength, value, 8);
-  if (ec != std::errc()) {
-    return NewError(InvalidConversion{});
-  }
-  return Success();
 }
 
 Status SerialiseHeader(common::ObjectHeader const &header,
                        std::span<char> buffer) {
+  using namespace cc::tar::helpers;
   if (buffer.size_bytes() < HEADER_SIZE_B)
     return NewError(InvalidBufferSize{});
-
   std::fill(buffer.begin(), buffer.end(), 0x00);
 
-  // Filename && Linked filename
-  std::copy_n(header.fileName.c_str(), header.fileName.size() + 1,
-              buffer.begin() + HeaderOffsets::FILE_NAME);
-  std::copy_n(header.linkedFileName.c_str(), header.linkedFileName.size() + 1,
-              buffer.begin() + HeaderOffsets::LINKED_FILE_NAME);
-
-  // Octal conversions
-  BOOST_LEAF_CHECK(ToOctalCharsN(header.fileSize,
-                                 buffer.data() + HeaderOffsets::FILE_SIZE, 12));
-  BOOST_LEAF_CHECK(ToOctalCharsN(header.fileSize,
-                                 buffer.data() + HeaderOffsets::FILE_SIZE, 12));
-  BOOST_LEAF_CHECK(ToOctalCharsN(header.fileMode,
-                                 buffer.data() + HeaderOffsets::FILE_MODE, 8));
+  BOOST_LEAF_CHECK(Write<common::FILE_NAME>(header.fileName, buffer));
+  BOOST_LEAF_CHECK(Write<common::FILE_MODE>(header.fileMode, buffer));
+  BOOST_LEAF_CHECK(Write<common::USER_ID>(header.userID, buffer));
+  BOOST_LEAF_CHECK(Write<common::GROUP_ID>(header.groupID, buffer));
+  BOOST_LEAF_CHECK(Write<common::FILE_SIZE>(header.fileSize, buffer));
+  BOOST_LEAF_CHECK(Write<common::LINK_INDICATOR>(header.linkIndicator, buffer));
   BOOST_LEAF_CHECK(
-      ToOctalCharsN(header.userID, buffer.data() + HeaderOffsets::USER_ID, 8));
-  BOOST_LEAF_CHECK(ToOctalCharsN(header.groupID,
-                                 buffer.data() + HeaderOffsets::GROUP_ID, 8));
-
-  // Link indicator
-  buffer[HeaderOffsets::LINK_INDICATOR] = header.linkIndicator + '0';
+      Write<common::LINKED_FILE_NAME>(header.linkedFileName, buffer));
 
   // Checksum
   auto checkSum = CalculateChecksum(buffer);
-  BOOST_LEAF_CHECK(
-      ToOctalCharsN(checkSum, buffer.data() + HeaderOffsets::CHECKSUM, 8));
+  BOOST_LEAF_CHECK(Write<common::CHECKSUM>(checkSum, buffer));
   return Success();
 }
 

--- a/src/internal/detail.hpp
+++ b/src/internal/detail.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <span>
 
 #include "common.hpp"


### PR DESCRIPTION
The aim of this PR is to make the parsing and serialisation of the tar object header buffer more type-safe and extendible. The following design changes were made to move towards this goal:

- Introduction of the `Field` struct to represent individual fields in the object header and the underlying data type
- Definition of the free functions `Write` and `Read` which serialise and parse fields to a buffer respectively
- Introduction of wrapper types `String_t`, `Octal_t` and `EnumClass_t` to specialise the parsing and serialisation behaviour

The decision was made to pursue an object-oriented approach to allow for easy extension of types rather than a visitor approach which would benefit extension of operations, since the set of operations (`Parse` and `Serialise`) are expected to remain unchanged during any further development.

This implementation is by no means perfect but I believe its a step in the right direction to make this code more readable and easier to work with. 